### PR TITLE
feat: implement syntax for conditional attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Supported template expressions are:
 | `[% import "uri" as "prefix" at "path" %]` | Import an XQuery module so its functions/variables can be used in template expressions. |
 | `[% raw %]…[% endraw %]` | Include the contained text as is, without parsing for templating expressions |
 | `[# … #]` | Single or multi-line comment: content will be discarded |
+| `attr="![[ expr ]]"` | Conditionally emit attribute `attr`: evaluate `expr` as boolean and output the attribute only if true |
 
 Here, `expr` must be a valid XPath expression.
 
@@ -74,6 +75,17 @@ For some real pages built with Jinks Templates, check the app manager of TEI Pub
 ## Output modes
 
 The Jinks Templates library supports two output modes: **XML/HTML** and **plain text**. They differ in the XQuery code that templates are compiled into. While the first will always return XML – and fails if the result is not well-formed, the second uses XQuery string templates.
+
+## Conditional attributes
+
+Conditional attributes are useful when templates should stay valid XML while still deciding at runtime whether an attribute should be present. Example:
+
+```xml
+<a class="![[ $expression ]]" href="/docs">Documentation</a>
+```
+
+If the effective boolean value of `$expression` is true, `class` is emitted; otherwise the `class` attribute is omitted completely. Note that the empty string, the empty sequence or the number 0 count as false.
+
 
 ## Use in XQuery
 

--- a/content/templates.xqm
+++ b/content/templates.xqm
@@ -110,6 +110,7 @@ declare variable $tmpl:TOKEN_REGEX := [
     "\[%\s*(block)\s+(.+?)%\]",
     "\[%\s*(template!?)\s+(\S+?)(?:\s+(.*?))?%\]",
     '\[%\s*(import)\s+["''](.+?)["'']\s+as\s+["'']([\w\-_]+)["''](?:\s+at\s+["''](.+?)["''])?\s*%\]',
+    '(([\w:.-]+)\s*=\s*"(!)\[\[(.+?)\]\]")',
     "\[(\[)(.+?)\]\]"
 ];
 
@@ -148,52 +149,60 @@ declare function tmpl:tokenize($input as xs:string) {
         typeswitch($token)
             case element(fn:match) return
                 let $type := $token/fn:group[1]
+                let $token-string := $token/string()
+                let $cond-attr := analyze-string($token-string, '^([\w:.-]+)\s*=\s*"(!)\[\[(.+?)\]\]"$', "s")
                 return
-                switch($type)
-                    case "endfor" return
-                        <endfor/>
-                    case "endlet" return
-                        <endlet/>
-                    case "endif" return
-                        <endif/>
-                    case "if" return
-                        <if expr="{$token/fn:group[2] => normalize-space()}"/>
-                    case "elif" return
-                        <elif expr="{$token/fn:group[2] => normalize-space()}"/>
-                    case "else" return
-                        <else/>
-                    case "for" return
-                        <for var="{$token/fn:group[2] => normalize-space()}" expr="{$token/fn:group[3] => normalize-space()}"/>
-                    case "let" return
-                        <let var="{$token/fn:group[2] => normalize-space()}" expr="{$token/fn:group[3] => normalize-space()}"/>
-                    case "include" return
-                        <include target="{$token/fn:group[2] => normalize-space()}"/>
-                    case "template" return
-                        <template name="{$token/fn:group[2] => normalize-space()}" 
-                            order="{$token/fn:group[3] => normalize-space()}"/>
-                    case "template!" return
-                        <template name="{$token/fn:group[2] => normalize-space()}" overwrite="true"/>
-                    case "endtemplate" return
-                        <endtemplate/>
-                    case "block" return
-                        <block name="{$token/fn:group[2] => normalize-space()}"/>
-                    case "endblock" return
-                        <endblock/>
-                    case "raw" return
-                        <raw>{ $token/fn:group[2] => normalize-space() }</raw>
-                    case "import" return
-                        <import uri="{$token/fn:group[2] => normalize-space()}" as="{$token/fn:group[3] => normalize-space()}">
-                        {
-                            if (count($token/fn:group) > 3) then
-                                attribute at {$token/fn:group[4] => normalize-space()}
-                            else
-                                ()
-                        }
-                        </import>
-                    case "[" return
-                        <value expr="{$token/fn:group[2] => normalize-space()}"/>
-                    default return
-                        <error>{$token}</error>
+                    if (count($cond-attr//fn:group) = 3 and $cond-attr//fn:group[@nr = 2] = "!") then
+                        <cond-attr
+                            name="{$cond-attr//fn:group[@nr = 1] => normalize-space()}"
+                            expr="{$cond-attr//fn:group[@nr = 3] => normalize-space()}"
+                        />
+                    else
+                        switch($type)
+                            case "endfor" return
+                                <endfor/>
+                            case "endlet" return
+                                <endlet/>
+                            case "endif" return
+                                <endif/>
+                            case "if" return
+                                <if expr="{$token/fn:group[2] => normalize-space()}"/>
+                            case "elif" return
+                                <elif expr="{$token/fn:group[2] => normalize-space()}"/>
+                            case "else" return
+                                <else/>
+                            case "for" return
+                                <for var="{$token/fn:group[2] => normalize-space()}" expr="{$token/fn:group[3] => normalize-space()}"/>
+                            case "let" return
+                                <let var="{$token/fn:group[2] => normalize-space()}" expr="{$token/fn:group[3] => normalize-space()}"/>
+                            case "include" return
+                                <include target="{$token/fn:group[2] => normalize-space()}"/>
+                            case "template" return
+                                <template name="{$token/fn:group[2] => normalize-space()}" 
+                                    order="{$token/fn:group[3] => normalize-space()}"/>
+                            case "template!" return
+                                <template name="{$token/fn:group[2] => normalize-space()}" overwrite="true"/>
+                            case "endtemplate" return
+                                <endtemplate/>
+                            case "block" return
+                                <block name="{$token/fn:group[2] => normalize-space()}"/>
+                            case "endblock" return
+                                <endblock/>
+                            case "raw" return
+                                <raw>{ $token/fn:group[2] => normalize-space() }</raw>
+                            case "import" return
+                                <import uri="{$token/fn:group[2] => normalize-space()}" as="{$token/fn:group[3] => normalize-space()}">
+                                {
+                                    if (count($token/fn:group) > 3) then
+                                        attribute at {$token/fn:group[4] => normalize-space()}
+                                    else
+                                        ()
+                                }
+                                </import>
+                            case "[" return
+                                <value expr="{$token/fn:group[2] => normalize-space()}"/>
+                            default return
+                                <error>{$token}</error>
             default return
                 $token/string()
 };
@@ -232,6 +241,52 @@ declare %private function tmpl:lookahead($tokens as item()*, $type as xs:string,
  :)
 declare function tmpl:parse($tokens as item()*, $resolver as function(*)?) {
     <ast>{tmpl:do-parse($tokens, $resolver)}</ast>
+};
+
+declare %private function tmpl:normalize-cond-attrs($nodes as item()*) {
+    let $normalized :=
+        for $node in $nodes
+        return
+            typeswitch($node)
+                case element(cond-attr) return
+                    $node
+                case element() return
+                    element { node-name($node) } {
+                        $node/@*,
+                        tmpl:normalize-cond-attrs($node/node())
+                    }
+                default return
+                    $node
+    return
+        tmpl:move-cond-attrs($normalized, (), ())
+};
+
+declare %private function tmpl:move-cond-attrs($nodes as item()*, $output as item()*, $pending as element(cond-attr)*) {
+    if (empty($nodes)) then
+        ($output, $pending)
+    else
+        let $next := head($nodes)
+        let $tail := tail($nodes)
+        return
+            typeswitch($next)
+                case element(cond-attr) return
+                    tmpl:move-cond-attrs($tail, $output, ($pending, $next))
+                case text() return
+                    if (exists($pending) and contains($next, ">")) then
+                        let $before := substring-before($next, ">")
+                        let $after := substring-after($next, ">")
+                        let $newOutput := (
+                            $output,
+                            text { $before || ">" },
+                            $pending,
+                            if ($after != "") then text { $after } else ()
+                        )
+                        return
+                            tmpl:move-cond-attrs($tail, $newOutput, ())
+                    else
+                        tmpl:move-cond-attrs($tail, ($output, $next), $pending)
+                default return
+                    tmpl:move-cond-attrs($tail, ($output, $next), $pending)
 };
 
 declare %private function tmpl:do-parse($tokens as item()*, $resolver as function(*)?) {
@@ -509,6 +564,20 @@ declare %private function tmpl:emit($config as map(*), $nodes as item()*) {
                         $config?enclose?start($node)
                         || "tmpl:valueOf(" || $expr || ")"
                         || $config?enclose?end($node)
+                case element(cond-attr) return
+                    let $expr :=
+                        if (matches($node/@expr, "^[^$][\w_-]+$")) then
+                            "$" || $node/@expr
+                        else
+                            $node/@expr
+                    let $attrName := $node/@name/string()
+                    return
+                        $config?enclose?start($node)
+                        || "let $value := tmpl:valueOf(" || $expr || ") return "
+                        || "if (count($value) > 1 or $value) then "
+                        || "attribute " || $attrName || " { $value }"
+                        || " else () "
+                        || $config?enclose?end($node)
                 case element(block) | element(import) return
                     ()
                 case element() return
@@ -600,6 +669,7 @@ declare function tmpl:to-ast($template as xs:string, $params as map(*), $config 
             ()
     ), map { "duplicates": "use-last" })
     let $ast := tmpl:tokenize($template) => tmpl:parse($config?resolver)
+    let $ast := <ast>{ tmpl:normalize-cond-attrs($ast/node()) }</ast>
     let $ast := tmpl:expand-blocks($ast, $incomingBlocks)
     return
         if ($extends) then

--- a/test/cypress/e2e/templateHtml.cy.js
+++ b/test/cypress/e2e/templateHtml.cy.js
@@ -237,4 +237,40 @@ describe('Template Content in HTML mode should', () => {
         // No expected output in fixture, so just check for successful processing
       })
     })
+
+    it('Process: conditional attribute expression emits attribute', () => {
+      const expected = '<div><a id="cta" class="btn-primary">Read more</a></div>'
+      cy.request({
+        method: 'POST',
+        url: '/',
+        body: {
+          template: '<div><a class="![[ $class ]]" id="cta">Read more</a></div>',
+          params: { class: 'btn-primary' },
+          mode: 'html'
+        },
+        failOnStatusCode: false
+      }).then(response => {
+        expect(response.status).to.eq(200)
+        expect(response.body).to.have.property('result')
+        expect(response.body.result).html.to.eq(expected)
+      })
+    })
+
+    it('Process: conditional attribute expression omits empty attribute', () => {
+      const expected = '<div><a id="cta">Read more</a></div>'
+      cy.request({
+        method: 'POST',
+        url: '/',
+        body: {
+          template: '<div><a class="![[ $class ]]" id="cta">Read more</a></div>',
+          params: { class: '' },
+          mode: 'html'
+        },
+        failOnStatusCode: false
+      }).then(response => {
+        expect(response.status).to.eq(200)
+        expect(response.body).to.have.property('result')
+        expect(response.body.result).html.to.eq(expected)
+      })
+    })
 })


### PR DESCRIPTION
Any attribute matching `attr="![[ expr ]]"` will be parsed into a `<cond-attr>` AST node. In a separate step, those nodes will be moved immediately after the closing `>` of their parent element. The emitter then outputs them as `attribute name { expr }`.

The proposed syntax keeps the template well-formed XML while making sure that attributes cannot be inserted in invalid locations.

Closes #24