### PR TITLE
fix: splice static includes without their ast wrapper

### DIFF
--- a/content/templates.xqm
+++ b/content/templates.xqm
@@ -422,7 +422,16 @@ declare %private function tmpl:do-parse($tokens as item()*, $resolver as functio
                 case element(include) return (
                     (: check if we can do a static include :)
                     if (matches($next/@target, '^"[^"]*"$')) then
-                        replace($next/@target, '^"([^"]*)"$', '$1') => tmpl:include-static($resolver)
+                        (: Splice in the parsed include's children, not its <ast> root:
+                         : a nested <ast> wrapper breaks the XML-mode code generator's
+                         : context heuristics. block?start takes the single <ast> element
+                         : for the "sole element child" case and omits the <t> wrapper,
+                         : while enclose?start sees parent::ast on the included template's
+                         : root nodes and emits braces - producing an enclosed expression
+                         : outside any element constructor (XPST0003) whenever a partial
+                         : starting with a control block (if/for/let) is included inside
+                         : another block. :)
+                        (replace($next/@target, '^"([^"]*)"$', '$1') => tmpl:include-static($resolver))/node()
                     else
                         $next,
                     tmpl:do-parse(tail($tokens), $resolver)

--- a/test/app/pages/conditional.html
+++ b/test/app/pages/conditional.html
@@ -1,0 +1,5 @@
+[% if $cached %]
+<p>cached</p>
+[% else %]
+<p>inline</p>
+[% endif %]

--- a/test/app/pages/items.html
+++ b/test/app/pages/items.html
@@ -1,0 +1,3 @@
+[% for $item in $items?* %]
+<li>[[ $item ]]</li>
+[% endfor %]

--- a/test/cypress/e2e/templateHtml.cy.js
+++ b/test/cypress/e2e/templateHtml.cy.js
@@ -145,6 +145,53 @@ describe('Template Content in HTML mode should', () => {
       })
     })
 
+    it('include a partial whose root is an if-block, inside another if', () => {
+      // Regression: the static-include splice used to insert the included
+      // template's <ast> wrapper into the surrounding tree, which broke the
+      // XML-mode generator's context heuristics whenever the partial started
+      // with a control block (if/for/let) and the include sat inside another
+      // block: XPST0003 at compile time.
+      const cases = [
+        [{show: true, cached: false}, '<header><p>inline</p></header>'],
+        [{show: true, cached: true}, '<header><p>cached</p></header>'],
+        [{show: false, cached: false}, '<header/>']
+      ]
+      cases.forEach(([params, expected]) => {
+        cy.request({
+          method: 'POST',
+          url: '/',
+          body: {
+            template: '<header>\n  [% if $show %]\n  [% include "pages/conditional.html" %]\n  [% endif %]\n</header>',
+            params,
+            mode: 'html'
+          },
+          failOnStatusCode: false
+        }).then(response => {
+          expect(response.status).to.eq(200)
+          expect(response.body).to.have.property('result')
+          expect(response.body.result).html.to.eq(expected)
+        })
+      })
+    })
+
+    it('include a partial whose root is a for-loop, inside an if', () => {
+      // Same regression, for-rooted partial.
+      cy.request({
+        method: 'POST',
+        url: '/',
+        body: {
+          template: '<ul>[% if $show %][% include "pages/items.html" %][% endif %]</ul>',
+          params: {show: true, items: ['one', 'two']},
+          mode: 'html'
+        },
+        failOnStatusCode: false
+      }).then(response => {
+        expect(response.status).to.eq(200)
+        expect(response.body).to.have.property('result')
+        expect(response.body.result).html.to.eq('<ul><li>one</li><li>two</li></ul>')
+      })
+    })
+
     it('Use imported module functions', () => {
       const expected = '<section><ul><li>Application title: My great new application</li></ul></section>'
       cy.request({


### PR DESCRIPTION
Fixes #84.

## Problem

`tmpl:do-parse`'s static-include branch splices the full `tmpl:parse` result — an `<ast>` wrapper element — into the surrounding tree. The XML-mode code generator was never designed to meet a nested `<ast>`; two of its context heuristics then contradict each other:

- `block?start` takes the single `<ast>` element for the sole-element-child case and omits the `<t>` wrapper (branch stays in expression context),
- `enclose?start` sees `parent::ast` on the included template's root nodes and emits `{…}`.

Together that produces a brace-enclosed expression outside any element constructor, so an `[% include %]` of a partial whose root is a control block (`if`/`for`/`let`), placed inside another block, fails with XPST0003 at compile time. Found in the wild (a menu partial rooted at an `[% if %]`, included from a layout's `[% if %]`), where every page rendered the error page.

## Fix

One line: splice the parsed include's *children* instead of its `<ast>` root, so a nested `<ast>` never appears mid-tree and included content compiles exactly like the same content written inline. Both heuristics keep working unchanged — unlike #55's approach of disabling the sole-element-child optimization wholesale, this targets the invariant the generator actually relies on (a single top-level `<ast>`).

## Tests

Two regression tests in `templateHtml.cy.js` with new test-app partials: an if-rooted partial included inside another if (both branch values plus the outer-false case), and a for-rooted partial included inside an if. Both fail against master with XPST0003 and pass with the fix.

Full cypress suite: 32/32 passing (api 6, api.security 3, templateCss 1, templateHtml 19, templateText 1, templateXquery 2) against the Docker test app.

Also verified against a wider sanity sweep run directly through `tmpl:process`: top-level static includes, plain-markup partials in and outside blocks, and text-mode processing behave identically before and after. (Text-mode `[% include %]` inside an `[% if %]` is broken both before and after — a separate, pre-existing issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)